### PR TITLE
Update SHA to SHA256.

### DIFF
--- a/git-radar.rb
+++ b/git-radar.rb
@@ -4,7 +4,7 @@ require 'formula'
 class GitRadar < Formula
   homepage 'https://github.com/michaeldfallen/git-radar'
   url 'https://github.com/michaeldfallen/git-radar/releases/download/v0.6/git-radar-0.6.tar.gz'
-  sha1 '27c9ebfe8470851099d3f4efe65370cf00c9b58d'
+  sha256 '8a2ba434134413e16d83a6dd8d98ba5e1d3ac782a0719abc27fc6feef6ca5a82'
 
   head 'https://github.com/michaeldfallen/git-radar.git'
 


### PR DESCRIPTION
Generated on OS X 10.11 via shasum -a 256 git-radar-0.6.tar.gz.

Should fix https://github.com/michaeldfallen/homebrew-formula/issues/5.
