### PR TITLE
So backslashes display in output

### DIFF
--- a/git-radar.rb
+++ b/git-radar.rb
@@ -21,10 +21,10 @@ class GitRadar < Formula
     ohai "Bash and Zsh installation
 
 Bash
-  export PS1=\"\W\$(git-radar --bash --fetch) \"
+  export PS1=\"\\W\\\$(git-radar --bash --fetch) \"
 
 Zsh
-  export PROMPT=\"%1/%\$(git-radar --zsh --fetch) \"
+  export PROMPT=\"%1/%\\\$(git-radar --zsh --fetch) \"
 "
   end
 end


### PR DESCRIPTION
Add delimiters to the backslashes so they appear in the post-install output
